### PR TITLE
Update README and schema for orbit definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ It will often be combined with other extensions that describe the actual data, s
 | ------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | sat:platform_international_designator | string                | The International Designator, also known as COSPAR ID, and NSSDCA ID                                                                                                                                    |
 | sat:orbit_state                       | string                | The state of the orbit. Either `ascending` or `descending` for polar orbiting satellites, or `geostationary` for geosynchronous satellites                                                              |
-| sat:absolute_orbit                    | integer               | The absolute orbit number at the time of acquisition.                                                                                                                                                   |
-| sat:relative_orbit                    | integer               | The relative orbit number at the time of acquisition.                                                                                                                                                   |
+| sat:absolute_orbit                    | integer               | The absolute orbit number at the start of acquisition.                                                                                                                                                  |
+| sat:relative_orbit                    | integer               | The relative orbit number at the start of acquisition.                                                                                                                                                  |
 | sat:orbit_cycle                       | integer               | The number of repeat cycle done by the satellite at the time of the acquisition. [Repeat cycle](https://ltb.itc.utwente.nl/page/498/concept/81577) is the time between two successive identical orbits. |
 | sat:orbit_state_vectors               | Map<string, \[number]> | The state vectors of the satellite at the time of acquisition.                                                                                                                                         |
 | sat:anx_datetime                      | string                | The [Ascending Node](https://en.wikipedia.org/wiki/Orbital_node) Crossing (ANX) time, in UTC. It is formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).    |
@@ -48,17 +48,25 @@ Indicates the type and current state of orbit. Satellites are either geosynchron
 
 #### sat:absolute_orbit
 
-A count of orbits from 1 to the number of orbits made in the total satellite lifecycle. In mission planning and tasking, the 
-absolute orbit may be used as a reference in the non systematic acquisition missions. The resulting Item can be tagged with the 
-absolute orbit and thus searchable as such. In the case of orbital changes during the mission modifying the ground track and 
-thus the repeat cycle and thus the number or relative orbits, the combination of cycle and relative orbit is not sufficient to 
+A count of orbits from 1 to the number of orbits made in the total satellite lifecycle. In mission planning and tasking, the
+absolute orbit may be used as a reference in the non systematic acquisition missions. The resulting Item can be tagged with the
+absolute orbit and thus searchable as such. In the case of orbital changes during the mission modifying the ground track and
+thus the repeat cycle and thus the number or relative orbits, the combination of cycle and relative orbit is not sufficient to
 derive an absolute orbit.
+
+When the orbit changes during data acquisition (i.e., the acquisition spans multiple orbits), the convention is to use the
+absolute orbit number at the start of the acquisition. This situation can occur, for example, in consolidated altimetry
+products such as Sentinel-3.
 
 #### sat:relative_orbit
 
-A count of orbits from 1 to the number of orbits contained in a repeat cycle, where relative orbit 1 starts from a specific 
-reference location of the sub-satellite point (the point on the earth directly below the satellite). It resets to 1 when the 
+A count of orbits from 1 to the number of orbits contained in a repeat cycle, where relative orbit 1 starts from a specific
+reference location of the sub-satellite point (the point on the earth directly below the satellite). It resets to 1 when the
 sub-satellite point revisits the reference location.
+
+When the orbit changes during data acquisition (i.e., the acquisition spans multiple orbits), the convention is to use the
+relative orbit number at the start of the acquisition. This situation can occur, for example, in consolidated altimetry
+products such as Sentinel-3.
 
 #### sat:anx_datetime
 

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -124,10 +124,14 @@
           ]
         },
         "sat:absolute_orbit": {
+          "title": "Absolute Orbit",
+          "description": "The absolute orbit number at the start of acquisition. When the orbit changes during data acquisition (i.e., the acquisition spans multiple orbits), use the absolute orbit number at the start of the acquisition.",
           "type": "integer",
           "minimum": 1
         },
         "sat:relative_orbit": {
+          "title": "Relative Orbit",
+          "description": "The relative orbit number at the start of acquisition. When the orbit changes during data acquisition (i.e., the acquisition spans multiple orbits), use the relative orbit number at the start of the acquisition.",
           "type": "integer",
           "minimum": 1
         },


### PR DESCRIPTION
Clarify the definitions of absolute and relative orbits in the README and JSON schema to specify that these values refer to the start of acquisition, especially in cases where the orbit changes during data acquisition.

Fixes #14