### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `crossing` value to `sat:orbit_state` for acquisitions spanning a polar crossing ([#1](https://github.com/stac-extensions/sat/issues/1))
-- Added `sat:acquisition_station` field ([#12](https://github.com/stac-extensions/sat/issues/12))
-
 ### Changed
 
 ### Deprecated
@@ -18,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+## [v1.2.0] - 2026-04-29
+
+### Added
+
+- Added `crossing` value to `sat:orbit_state` for acquisitions spanning a polar crossing ([#1](https://github.com/stac-extensions/sat/issues/1))
+- Added `sat:acquisition_station` field ([#12](https://github.com/stac-extensions/sat/issues/12))
 
 ## [v1.1.0] - 2024-12-19
 
@@ -39,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sat:absolute_orbit`
   - `sat:anx_datetime`
 
-[Unreleased]: <https://github.com/stac-extensions/sat/compare/v1.1.0...HEAD>
+[Unreleased]: <https://github.com/stac-extensions/sat/compare/v1.2.0...HEAD>
+[v1.2.0]: <https://github.com/stac-extensions/sat/compare/v1.1.0...v1.2.0>
 [v1.1.0]: <https://github.com/stac-extensions/sat/compare/v1.0.0...v1.1.0>
 [v1.0.0]: <https://github.com/stac-extensions/sat/tree/v1.0.0>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Satellite Extension Specification
 
 - **Title:** Satellite
-- **Identifier:** <https://stac-extensions.github.io/sat/v1.1.0/schema.json>
+- **Identifier:** <https://stac-extensions.github.io/sat/v1.2.0/schema.json>
 - **Field Name Prefix:** sat
 - **Scope:** Item, Collection
 - **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Candidate

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Identifier:** <https://stac-extensions.github.io/sat/v1.2.0/schema.json>
 - **Field Name Prefix:** sat
 - **Scope:** Item, Collection
-- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Candidate
+- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Stable
 - **Owner**: @emmanuelmathot
 - **History**: [Prior to March 2, 2021](https://github.com/radiantearth/stac-spec/commits/v1.0.0-rc.1/extensions/sat)
 

--- a/examples/example-landsat8.json
+++ b/examples/example-landsat8.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/sat/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.2.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "id": "LC08_L1TP_107018_20181001",

--- a/examples/example-sentinel1.json
+++ b/examples/example-sentinel1.json
@@ -2,7 +2,7 @@
   "stac_version": "1.1.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/sar/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/sat/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/sat/v1.2.0/schema.json"
   ],
   "id": "S1A_IW_SLC__1SDV_20150305T051937_20150305T052005_004892_006196_ABBB",
   "type": "Feature",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/sat/v1.1.0/schema.json",
+  "$id": "https://stac-extensions.github.io/sat/v1.2.0/schema.json",
   "title": "Satellite Extension",
   "description": "STAC Sat Extension to a STAC Item.",
   "type": "object",
@@ -11,7 +11,7 @@
     "stac_extensions": {
       "type": "array",
       "contains": {
-        "const": "https://stac-extensions.github.io/sat/v1.1.0/schema.json"
+        "const": "https://stac-extensions.github.io/sat/v1.2.0/schema.json"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "stac-extension-sat",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/sat/v1.1.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/sat/v1.1.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/sat/v1.2.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/sat/v1.2.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^12.0.0",


### PR DESCRIPTION
Update the version to 1.2.0 and adjust the changelog, README, examples, and package.json to reflect the new features and changes. This includes updating schema references in examples to the new version.